### PR TITLE
Fix for issue #10

### DIFF
--- a/virtualenv-burrito.py
+++ b/virtualenv-burrito.py
@@ -157,8 +157,8 @@ def upgrade_package(filename, name, version):
             sh("%s setup.py easy_install --exclude-scripts --install-dir %s %s >/dev/null"
                % (sys.executable, os.path.join(VENVBURRITO_LIB, "python"), egg))
         else:
-            sh("%s setup.py install --home %s --no-compile >/dev/null"
-               % (sys.executable, VENVBURRITO))
+            sh("%s setup.py install --home %s --install-scripts %s --no-compile >/dev/null"
+               % (sys.executable, VENVBURRITO, os.path.join(VENVBURRITO, "bin")))
         if name in ['virtualenv', 'virtualenvwrapper']:
             fix_bin_virtualenv()
     finally:


### PR DESCRIPTION
After digging around, I found that it was (for whatever reason) picking up the wrong script install dir. So I just added a switch to override that as well. After doing this, it worked fine. 
