### PR TITLE
upgrade virtualenv to latest version (1.10.1)

### DIFF
--- a/test_download.py
+++ b/test_download.py
@@ -11,7 +11,7 @@ PYPI_MD5_URL = 'http://pypi.python.org/pypi?:action=show_md5&digest='
 PYPI_DOWNLOADS = {
     # filename: md5sum
     'distribute-0.6.49.tar.gz': '89e68df89faf1966bcbd99a0033fbf8e',
-    'virtualenv-1.9.1.tar.gz': '07e09df0adfca0b2d487e39a4bf2270a',
+    'virtualenv-1.10.1.tar.gz': '3a04aa2b32c76c83725ed4d9918e362e',
     'virtualenvwrapper-4.0.tar.gz': '78df3b40735e959479d9de34e4b8ba15',
 }
 

--- a/versions.csv
+++ b/versions.csv
@@ -1,4 +1,4 @@
 _virtualenv-burrito,2.0.5,https://raw.github.com/brainsik/virtualenv-burrito/master/virtualenv-burrito.py,34851089c91f5483dc7934d3b87cfb7d3c16166e
 distribute,0.6.49,https://pypi.python.org/packages/source/d/distribute/distribute-0.6.49.tar.gz,a62cfe21bd0e5e2913c5b576f872ca293b9bebca
-virtualenv,1.9.1,https://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.9.1.tar.gz,b7d1704ec186a71c2fff1706896ecd294b708a55
+virtualenv,1.10.1,https://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.10.1.tar.gz,0c441553f97a1ed68bb2032c9ab65e6c3bc38e24
 virtualenvwrapper,4.0,https://pypi.python.org/packages/source/v/virtualenvwrapper/virtualenvwrapper-4.0.tar.gz,a1b380e7efa495a3aaa7c8e4395ec3e717b95400


### PR DESCRIPTION
Here's a fork with an updated `version.csv` pointing at the latest virtualenv version, as i suggested in #36.

Feel free to merge it whenever you feel like dropping py25.
