### PR TITLE
Remove test dependency on nose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: python
 python:
   - "2.7"
 install: true
-script:  nosetests
+script: py.test

--- a/test_download.py
+++ b/test_download.py
@@ -4,7 +4,6 @@ import urllib2
 import csv
 import hashlib
 
-from nose.tools import eq_
 
 PYPI_MD5_URL = 'https://pypi.python.org/pypi?:action=show_md5&digest='
 
@@ -15,6 +14,11 @@ PYPI_DOWNLOADS = {
     'virtualenv-14.0.6.tar.gz': 'a035037925c82990a7659ecf8764bcdb',
     'virtualenvwrapper-4.7.1.tar.gz': '3789e0998818d9a8a4ec01cfe2a339b2',
 }
+
+
+def eq_(a, b, msg=None):
+    if not a == b:
+        raise AssertionError(msg or "%r != %r" % (a, b))
 
 
 def test_tarball_names():


### PR DESCRIPTION
The only thing that depended on nose was this `eq_` function, and since it's so trivial, I just vendored it.